### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -150,7 +150,7 @@ class syntax_plugin_bugzillaxmlrpc extends DokuWiki_Syntax_Plugin {
     }
 
 
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         preg_match('/^bugz#([0-9]+)/', $match, $submatch);
         $ids = $submatch[1];
         $data_bugs = array(); // two-dimensional array
@@ -191,7 +191,7 @@ class syntax_plugin_bugzillaxmlrpc extends DokuWiki_Syntax_Plugin {
     }
 
 
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if($mode == 'xhtml'){
             $data0 = $data[0];
             $html_bug_all = '<ul>' . "\n";


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
